### PR TITLE
Fix metadata

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cryptid",
-  "version": "0.0.2",
+  "version": "0.0.3",
   "description": "javascript client to cryptid analytics",
   "website": "https://cryptid.adorable.io",
   "main": "dist/index.js",

--- a/src/browser.js
+++ b/src/browser.js
@@ -2,8 +2,8 @@ export default function collectBrowserMetadata() {
   return {
     document_location_url: window.location.href,
     document_referer: window.document.referrer,
-    document_encoding: document.characterSet,
-    document_title: document.window.title,
+    document_encoding: window.document.characterSet,
+    document_title: window.document.title,
     document_hostname: window.location.hostname,
     document_path: window.location.path,
     user_language: window.navigator.language || window.navigator.userLanguage,


### PR DESCRIPTION
Fixes a typo where `window.document` was referenced as `document.window`. :sad_trombone: