### PR TITLE
Adds trackerId to payload

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cryptid",
-  "version": "0.0.3",
+  "version": "0.0.4",
   "description": "javascript client to cryptid analytics",
   "website": "https://cryptid.adorable.io",
   "main": "dist/index.js",

--- a/src/index.js
+++ b/src/index.js
@@ -23,7 +23,11 @@ function Tracker(trackerId, options) {
 
 Tracker.prototype.send = function(event) {
   const metadata = collectBrowserMetadata();
-  let mergedEvent = {...metadata, ...event };
+  let mergedEvent = {
+    trackerId: this.trackerId,
+    ...metadata,
+    ...event
+  };
   const config = generateRequestOptions();
   let mergedConfig = {...config, ...this.options };
   sendData(mergedEvent, mergedConfig);


### PR DESCRIPTION
Forgot that we need to include the trackerId in the payload to cryptid so it knows where to log it.