### PR TITLE
Conditionally deploy

### DIFF
--- a/bin/deploy_if_version_changed
+++ b/bin/deploy_if_version_changed
@@ -1,0 +1,16 @@
+#!/usr/bin/env sh
+
+localVersion=`cat package.json | $(npm bin)/jq2 '$.version'`
+echo "Local version is at $localVersion"
+
+repoVersion=`npm view cryptid version`
+echo "Repository version is at $repoVersion"
+
+if [ -z `$(npm bin)/semver -r ">$repoVersion" $localVersion` ]; then
+  echo "Local version is less than or equal to repository version. Will not deploy."
+else
+  echo "Local version increments past repository version. Deploying."
+  `$(npm bin)/ci-publish`
+fi
+
+

--- a/package-lock.json
+++ b/package-lock.json
@@ -4803,6 +4803,15 @@
         }
       }
     },
+    "jq2": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/jq2/-/jq2-1.0.1.tgz",
+      "integrity": "sha1-JBcyxFMSpCyeFuLrJvehH0VnfqE=",
+      "dev": true,
+      "requires": {
+        "lodash": "4.17.4"
+      }
+    },
     "js-tokens": {
       "version": "3.0.2",
       "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-3.0.2.tgz",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "cryptid",
-  "version": "0.0.1",
+  "version": "0.0.5",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cryptid",
-  "version": "0.0.4",
+  "version": "0.0.5",
   "description": "javascript client to cryptid analytics",
   "website": "https://cryptid.adorable.io",
   "main": "dist/index.js",

--- a/package.json
+++ b/package.json
@@ -25,7 +25,9 @@
     "eslint": "^4.6.1",
     "eslint-plugin-jest": "^21.0.0",
     "eslint-plugin-prefer-object-spread": "^1.2.1",
-    "jest": "^21.0.1"
+    "jest": "^21.0.1",
+    "jq2": "^1.0.1",
+    "semver": "^5.4.1"
   },
   "jest": {
     "collectCoverage": true,


### PR DESCRIPTION
We deploy to npm on merge to master, but the `publish` command fails if we try to publish via the `ci-publish` command but the version hasn't changed. This PR adds a new script in `bin/` that checks both the local and npm registry versions of the package, and only invokes `ci-publish` if the local version is higher than the registry version.