### PR TITLE
Encloses data payload in the expected envelope

### DIFF
--- a/__tests__/index.test.js
+++ b/__tests__/index.test.js
@@ -29,11 +29,13 @@ describe('#track', () => {
   it('merges supplied event data with browser metadata', () => {
     tracker.send(event);
     expect(tracker.reqwest).toBeCalledWith(expect.objectContaining({
-      data: expect.objectContaining({
-        documentLocationUrl: "http://example.org/hello/world.html",
-        eventValue: "button-click",
-        userLanguage: "en-GB",
-      }),
+      data: {
+        event: expect.objectContaining({
+          documentLocationUrl: "http://example.org/hello/world.html",
+          eventValue: "button-click",
+          userLanguage: "en-GB",
+        })
+      }
     }));
   });
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cryptid",
-  "version": "0.0.5",
+  "version": "0.0.6",
   "description": "javascript client to cryptid analytics",
   "website": "https://cryptid.adorable.io",
   "main": "dist/index.js",

--- a/src/index.js
+++ b/src/index.js
@@ -24,9 +24,11 @@ function Tracker(trackerId, options) {
 Tracker.prototype.send = function(event) {
   const metadata = collectBrowserMetadata();
   let mergedEvent = {
-    trackerId: this.trackerId,
-    ...metadata,
-    ...event
+    event: {
+      trackerId: this.trackerId,
+      ...metadata,
+      ...event
+    }
   };
   const config = generateRequestOptions();
   let mergedConfig = {...config, ...this.options };


### PR DESCRIPTION
The service expects a specific format of the payload to be included inside an "event" object in the request.