### PR TITLE
Product CLI support

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "cryptid",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cryptid",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "description": "javascript client to cryptid analytics",
   "website": "https://cryptid.adorable.io",
   "main": "dist/index.js",

--- a/package.json
+++ b/package.json
@@ -53,6 +53,7 @@
     "commander": "^2.11.0",
     "easy-table": "^1.1.0",
     "inquirer": "^3.2.3",
+    "lodash": "^4.17.4",
     "md5": "^2.2.1",
     "preferences": "^0.2.1",
     "request": "^2.81.0",

--- a/src/bin/cli.js
+++ b/src/bin/cli.js
@@ -6,6 +6,7 @@ import request from 'request';
 import url from 'url';
 
 export const SERVER = process.env.CRYPTID_SERVER || 'https://cryptid.adorable.io';
+export const LOGGER = createLogger({level: createLogger.INFO});
 
 function buildUrl(path) {
   return url.resolve(SERVER, path);
@@ -15,14 +16,19 @@ function loadSettings() {
   let name = `com.adorable.cryptid.${md5(SERVER)}`;
   let settings = new Preferences(name, {server: SERVER, token: '', email: ''});
 
-  settings.isLoggedIn = settings.token.length > 0 && settings.email.length > 0;
-  settings.needsLogin = !settings.isLoggedIn;
+  let loggedIn = settings.token.length > 0 && settings.email.length > 0;
+  settings.loggedIn = loggedIn;
+  settings.checkLogin = () => {
+    if (!loggedIn) {
+      LOGGER.info(chalk.red('You must first login with "cryptid login"'));
+      process.exit(1);
+    }
+  };
 
   return settings;
 }
 export const SETTINGS = loadSettings();
 export const TOKEN = SETTINGS.token;
-export const LOGGER = createLogger({level: createLogger.INFO});
 
 export function login(username, password) {
   let options = {

--- a/src/bin/cli.js
+++ b/src/bin/cli.js
@@ -157,3 +157,21 @@ export function updatePassword(passwords, callback) {
     callback(response, body);
   });
 }
+
+export function createProduct(accountId, productName, callback) {
+  let options = {
+    url: buildUrl(`/api/accounts/${accountId}/products`),
+    method: 'post',
+    headers: {Authorization: `Token token=${TOKEN}`},
+    json: {
+      product: {
+        name: productName
+      }
+    }
+  };
+
+  request(options, (error, response, body) => {
+    checkError(error);
+    callback(response, body);
+  });
+}

--- a/src/bin/cli.js
+++ b/src/bin/cli.js
@@ -175,3 +175,23 @@ export function createProduct(accountId, productName, callback) {
     callback(response, body);
   });
 }
+
+export function updateProduct(data, callback) {
+  let {accountId, productId, productName} = data;
+
+  let options = {
+    url: buildUrl(`/api/accounts/${accountId}/products/${productId}`),
+    method: 'put',
+    headers: {Authorization: `Token token=${TOKEN}`},
+    json: {
+      product: {
+        name: productName
+      }
+    }
+  };
+
+  request(options, (error, response, body) => {
+    checkError(error);
+    callback(response, body);
+  });
+}

--- a/src/bin/cli.js
+++ b/src/bin/cli.js
@@ -1,15 +1,17 @@
 import Preferences from 'preferences';
 import chalk from 'chalk';
 import createLogger from 'cli-logger';
+import fs from 'fs';
 import md5 from 'md5';
+import path from 'path';
 import request from 'request';
 import url from 'url';
 
 export const SERVER = process.env.CRYPTID_SERVER || 'https://cryptid.adorable.io';
 export const LOGGER = createLogger({level: createLogger.INFO});
 
-function buildUrl(path) {
-  return url.resolve(SERVER, path);
+function buildUrl(uri) {
+  return url.resolve(SERVER, uri);
 }
 
 function loadSettings() {
@@ -35,6 +37,21 @@ function checkError(error) {
     LOGGER.info(chalk.red(`Could not reach cryptid server. Is ${SERVER} reachable?`));
     process.exit(1);
   }
+}
+
+/* =========================================================
+ *
+ *  Helper Functions
+ *
+ *  ========================================================= */
+
+export function loadHelp(filename) {
+  let helpFilePath = path.join(__dirname, 'help', `${filename}.txt`);
+  return fs.readFileSync(helpFilePath, 'utf8');
+}
+
+export function loadVersion() {
+  return require(path.join(__dirname, '../..', 'package.json')).version;
 }
 
 /* =========================================================

--- a/src/bin/cryptid-accounts-add-user.js
+++ b/src/bin/cryptid-accounts-add-user.js
@@ -13,10 +13,7 @@ program
   .option('-e, --email <email>', 'Email of the user to add')
   .parse(process.argv);
 
-if (SETTINGS.needsLogin) {
-  LOGGER.info(chalk.red('You must first login with "cryptid login"'));
-  process.exit(1);
-}
+SETTINGS.checkLogin();
 
 if (!program.email) {
   LOGGER.info(chalk.red('Email is required (use -e <email>)'));

--- a/src/bin/cryptid-accounts-add-user.js
+++ b/src/bin/cryptid-accounts-add-user.js
@@ -1,6 +1,5 @@
 import {
   LOGGER,
-  SERVER,
   SETTINGS,
   addUserToAccount
 } from './cli';
@@ -25,12 +24,7 @@ if (!program.accountId) {
   process.exit(1);
 }
 
-addUserToAccount(program.accountId, program.email, (error, response, body) => {
-  if (error && error.code === 'ENOTFOUND') {
-    LOGGER.info(chalk.red(`Could not reach cryptid SERVER. Is ${SERVER} reachable?`));
-    process.exit(1);
-  }
-
+addUserToAccount(program.accountId, program.email, (response, body) => {
   if (response.statusCode === 201) {
     let {email, password} = body.data;
     LOGGER.info(chalk.green('User was created and added to account. Give them the following credentials to use:\n'));
@@ -41,13 +35,13 @@ addUserToAccount(program.accountId, program.email, (error, response, body) => {
     let {email} = body.data;
     LOGGER.info(chalk.yellow(`Existing user ${email} was successfully added to the account.`));
   } else if (response.statusCode === 400) {
-    LOGGER.info(chalk.red(`The user ${program.email} already has access to that account`));
+    LOGGER.error(chalk.red(`The user ${program.email} already has access to that account`));
     process.exit(1);
   } else if (response.statusCode === 404) {
-    LOGGER.info(chalk.red('Account not found'));
+    LOGGER.error(chalk.red('Account not found'));
     process.exit(1);
   } else if (response.statusCode === 403) {
-    LOGGER.info(chalk.red('Invalid account'));
+    LOGGER.error(chalk.red('Invalid account'));
     process.exit(1);
   }
 });

--- a/src/bin/cryptid-accounts-create.js
+++ b/src/bin/cryptid-accounts-create.js
@@ -1,6 +1,5 @@
 import {
   LOGGER,
-  SERVER,
   SETTINGS,
   createAccount
 } from './cli';
@@ -21,12 +20,7 @@ if (!program.accountName) {
   process.exit(1);
 }
 
-createAccount(program.accountName, (error, response, body) => {
-  if (error && error.code === 'ENOTFOUND') {
-    LOGGER.info(chalk.red(`Could not reach cryptid SERVER. Is ${SERVER} reachable?`));
-    process.exit(1);
-  }
-
+createAccount(program.accountName, (response, body) => {
   if (response.statusCode === 201) {
     let t = new Table();
 

--- a/src/bin/cryptid-accounts-create.js
+++ b/src/bin/cryptid-accounts-create.js
@@ -14,10 +14,7 @@ program
   .parse(process.argv);
 
 
-if (SETTINGS.needsLogin) {
-  LOGGER.info(chalk.red('You must first login with "cryptid login"'));
-  process.exit(1);
-}
+SETTINGS.checkLogin();
 
 if (!program.accountName) {
   LOGGER.info(chalk.red('Account name is required (use -n <accountName>)'));

--- a/src/bin/cryptid-accounts-list.js
+++ b/src/bin/cryptid-accounts-list.js
@@ -16,8 +16,8 @@ fetchCurrentUser((response, body) => {
     let user = body.data;
 
     user.accounts.forEach((account) => {
-      t.cell('id', account.id);
-      t.cell('account name', account.name);
+      t.cell('ID', account.id);
+      t.cell('Account Name', account.name);
       t.newRow();
     });
 

--- a/src/bin/cryptid-accounts-list.js
+++ b/src/bin/cryptid-accounts-list.js
@@ -1,6 +1,5 @@
 import {
   LOGGER,
-  SERVER,
   SETTINGS,
   fetchCurrentUser
 } from './cli';
@@ -10,16 +9,11 @@ import chalk from 'chalk';
 
 SETTINGS.checkLogin();
 
-fetchCurrentUser((error, response, body) => {
-  if (error && error.code === 'ENOTFOUND') {
-    LOGGER.info(chalk.red(`Could not reach cryptid SERVER. Is ${SERVER} reachable?`));
-    process.exit(1);
-  }
-
+fetchCurrentUser((response, body) => {
   if (response.statusCode === 200) {
     let t = new Table();
 
-    let user = JSON.parse(body).data;
+    let user = body.data;
 
     user.accounts.forEach((account) => {
       t.cell('id', account.id);

--- a/src/bin/cryptid-accounts-list.js
+++ b/src/bin/cryptid-accounts-list.js
@@ -8,10 +8,7 @@ import {
 import Table from 'easy-table';
 import chalk from 'chalk';
 
-if (SETTINGS.needsLogin) {
-  LOGGER.info(chalk.red('You must first login with "cryptid login"'));
-  process.exit(1);
-}
+SETTINGS.checkLogin();
 
 fetchCurrentUser((error, response, body) => {
   if (error && error.code === 'ENOTFOUND') {

--- a/src/bin/cryptid-accounts-update.js
+++ b/src/bin/cryptid-accounts-update.js
@@ -14,10 +14,7 @@ program
   .option('-n, --account-name <accountName>', 'Account name')
   .parse(process.argv);
 
-if (SETTINGS.needsLogin) {
-  LOGGER.info(chalk.red('You must first login with "cryptid login"'));
-  process.exit(1);
-}
+SETTINGS.checkLogin();
 
 if (!program.accountName) {
   LOGGER.info(chalk.red('Account name is required (use -n <accountName>)'));

--- a/src/bin/cryptid-accounts-update.js
+++ b/src/bin/cryptid-accounts-update.js
@@ -1,6 +1,5 @@
 import {
   LOGGER,
-  SERVER,
   SETTINGS,
   updateAccount
 } from './cli';
@@ -17,21 +16,16 @@ program
 SETTINGS.checkLogin();
 
 if (!program.accountName) {
-  LOGGER.info(chalk.red('Account name is required (use -n <accountName>)'));
+  LOGGER.error(chalk.red('Account name is required (use -n <accountName>)'));
   process.exit(1);
 }
 
 if (!program.accountId) {
-  LOGGER.info(chalk.red('Account id is required (use -a <accountId>)'));
+  LOGGER.error(chalk.red('Account id is required (use -a <accountId>)'));
   process.exit(1);
 }
 
-updateAccount(program.accountId, program.accountName, (error, response, body) => {
-  if (error && error.code === 'ENOTFOUND') {
-    LOGGER.info(chalk.red(`Could not reach cryptid SERVER. Is ${SERVER} reachable?`));
-    process.exit(1);
-  }
-
+updateAccount(program.accountId, program.accountName, (response, body) => {
   if (response.statusCode === 200) {
     let t = new Table();
 
@@ -45,8 +39,7 @@ updateAccount(program.accountId, program.accountName, (error, response, body) =>
 
     LOGGER.info(t.toString());
   } else {
-    LOGGER.info(response.statusCode);
-    LOGGER.info(chalk.red('Error updating account'));
+    LOGGER.error(chalk.red('Error updating account'));
     process.exit(1);
   }
 });

--- a/src/bin/cryptid-login.js
+++ b/src/bin/cryptid-login.js
@@ -16,7 +16,7 @@ program
 let username = program.username;
 let password = program.password;
 
-if (SETTINGS.isLoggedIn) {
+if (SETTINGS.loggedIn) {
   LOGGER.info(chalk.yellow(`You are already logged-in as ${SETTINGS.email}`));
   process.exit();
 }

--- a/src/bin/cryptid-logout.js
+++ b/src/bin/cryptid-logout.js
@@ -2,5 +2,7 @@ import {SETTINGS} from './cli';
 
 SETTINGS.token = '';
 SETTINGS.email = '';
+SETTINGS.loggedIn = false;
+delete SETTINGS.checkLogin;
 
 process.exit();

--- a/src/bin/cryptid-products-create.js
+++ b/src/bin/cryptid-products-create.js
@@ -1,0 +1,47 @@
+import {
+  LOGGER,
+  SETTINGS,
+  createProduct,
+} from './cli';
+
+import Table from 'easy-table';
+import chalk from 'chalk';
+import program from 'commander';
+
+program
+  .option('-a, --account-id <accountId>', 'Account to add the product to')
+  .option('-n, --product-name <productName>', 'Name of the new product')
+  .parse(process.argv);
+
+SETTINGS.checkLogin();
+
+if (!program.accountId) {
+  LOGGER.info(chalk.red('Account id is required (use -a <accountId>)'));
+  process.exit(1);
+}
+
+if (!program.productName) {
+  LOGGER.error(chalk.red('Product name is required (use -n <productName>'));
+  process.exit(1);
+}
+
+let {accountId, productName} = program;
+
+createProduct(accountId, productName, (response, body) => {
+  if (response.statusCode === 201) {
+    let t = new Table();
+
+    let product = body.data;
+
+    LOGGER.info(chalk.green(`Created product ${product.name}\n`));
+
+    t.cell('ID', product.id);
+    t.cell('Product Name', product.name);
+    t.newRow();
+
+    LOGGER.info(t.toString());
+  } else {
+    LOGGER.error(chalk.red('Error creating product'));
+    process.exit(1);
+  }
+});

--- a/src/bin/cryptid-products-list.js
+++ b/src/bin/cryptid-products-list.js
@@ -1,0 +1,45 @@
+import {
+  LOGGER,
+  SETTINGS,
+  fetchCurrentUser,
+} from './cli';
+
+import Table from 'easy-table';
+import chalk from 'chalk';
+import {find} from 'lodash';
+import program from 'commander';
+
+program
+  .option('-a, --account-id <accountId>', 'Account to fetch products for')
+  .parse(process.argv);
+
+SETTINGS.checkLogin();
+
+if (!program.accountId) {
+  LOGGER.error(chalk.red('Account id is required (use -a <accountId>)'));
+  process.exit(1);
+}
+
+fetchCurrentUser((response, body) => {
+  if (response.statusCode === 200) {
+    let account = find(body.data.accounts, {id: parseInt(program.accountId, 10)});
+
+    if (account) {
+      let t = new Table();
+
+      account.products.forEach((product) => {
+        t.cell('ID', product.id);
+        t.cell('Product Name', product.name);
+        t.newRow();
+      });
+
+      LOGGER.info(t.toString());
+    } else {
+      LOGGER.error(chalk.red(`Invalid account id: ${program.accountId}`));
+      process.exit(1);
+    }
+  } else {
+    LOGGER.error(chalk.red('Error fetching products'));
+    process.exit(1);
+  }
+});

--- a/src/bin/cryptid-products-update.js
+++ b/src/bin/cryptid-products-update.js
@@ -1,0 +1,51 @@
+import {
+  LOGGER,
+  SETTINGS,
+  updateProduct
+} from './cli';
+
+import Table from 'easy-table';
+import chalk from 'chalk';
+import program from 'commander';
+
+program
+  .option('-a, --account-id <accountId>', 'ID of account containing product')
+  .option('-p, --product-id <productId>', 'ID of product to update')
+  .option('-n, --product-name <productName>', 'Updated name of the product')
+  .parse(process.argv);
+
+SETTINGS.checkLogin();
+
+if (!program.accountId) {
+  LOGGER.error(chalk.red('Account ID is required (use -a <accountId>)'));
+  process.exit(1);
+}
+
+if (!program.productId) {
+  LOGGER.error(chalk.red('Product ID is required (use -p <productId>)'));
+  process.exit(1);
+}
+
+if (!program.productName) {
+  LOGGER.error(chalk.red('Product name is required (use -n <productName>)'));
+  process.exit(1);
+}
+
+updateProduct(program, (response, body) => {
+  if (response.statusCode === 200) {
+    let t = new Table();
+
+    let product = body.data;
+
+    LOGGER.info(chalk.green(`Updated product ${product.name}\n`));
+
+    t.cell('ID', product.id);
+    t.cell('Product Name', product.name);
+    t.newRow();
+
+    LOGGER.info(t.toString());
+  } else {
+    LOGGER.error(chalk.red('Error updating product'));
+    process.exit(1);
+  }
+});

--- a/src/bin/cryptid-products.js
+++ b/src/bin/cryptid-products.js
@@ -3,4 +3,5 @@ import program from 'commander';
 program
   .description('Product actions on a cryptid account')
   .command('list', 'List products for an account')
+  .command('create', 'Create a new product')
   .parse(process.argv);

--- a/src/bin/cryptid-products.js
+++ b/src/bin/cryptid-products.js
@@ -1,0 +1,6 @@
+import program from 'commander';
+
+program
+  .description('Product actions on a cryptid account')
+  .command('list', 'List products for an account')
+  .parse(process.argv);

--- a/src/bin/cryptid-products.js
+++ b/src/bin/cryptid-products.js
@@ -4,4 +4,5 @@ program
   .description('Product actions on a cryptid account')
   .command('list', 'List products for an account')
   .command('create', 'Create a new product')
+  .command('update', 'Update a product')
   .parse(process.argv);

--- a/src/bin/cryptid-user-change-password.js
+++ b/src/bin/cryptid-user-change-password.js
@@ -1,6 +1,5 @@
 import {
   LOGGER,
-  SERVER,
   SETTINGS,
   updatePassword
 } from './cli';
@@ -11,73 +10,41 @@ import program from 'commander';
 
 program
   .description('Change the password of your Cryptid account')
-  .option('-c, --current-password <currentPassword>', 'Your current password')
-  .option('-n, --new-password <newPassword>', 'Your new password')
   .parse(process.argv);
-
-let currentPassword = program.currentPassword;
-let newPassword = program.newPassword;
 
 SETTINGS.checkLogin();
 
-function callUpdatePassword(old, updated) {
-  updatePassword(old, updated, (error, response) => {
-    if (error && error.code === 'ENOTFOUND') {
-      LOGGER.info(chalk.red(`Could not reach cryptid SERVER. Is ${SERVER} reachable?`));
-      process.exit(1);
-    }
+let questions = [];
 
+questions.push({
+  type: 'password',
+  name: 'currentPassword',
+  message: 'Enter your current password:',
+  validate: (entry) => entry.length > 0,
+});
+
+questions.push({
+  type: 'password',
+  name: 'newPassword',
+  message: 'Enter your new password:',
+  validate: (entry) => entry.length > 0,
+});
+
+questions.push({
+  type: 'password',
+  name: 'newPasswordConfirm',
+  message: 'Enter your new password again:',
+  validate: (entry) => entry.length > 0,
+});
+
+inquirer.prompt(questions).then((answers) => {
+  updatePassword(answers, (response) => {
     if (response.statusCode === 200) {
       LOGGER.info(chalk.green('Your password has been updated'));
     } else {
-      LOGGER.info(response.statusCode);
-      LOGGER.info(chalk.red('An error has occurred'));
+      LOGGER.error(chalk.red('An error has occurred. Password not updated.'));
+      process.exit(1);
     }
   });
-}
-
-if (currentPassword && newPassword) {
-  callUpdatePassword(currentPassword, newPassword);
-} else {
-  let questions = [];
-
-  if (!currentPassword) {
-    questions.push({
-      type: 'password',
-      name: 'currentPassword',
-      message: 'Enter your current password:',
-      validate: (entry) => entry.length > 0,
-    });
-  }
-
-  if (!newPassword) {
-    questions.push({
-      type: 'password',
-      name: 'newPassword',
-      message: 'Enter your new password:',
-      validate: (entry) => entry.length > 0,
-    });
-
-    questions.push({
-      type: 'password',
-      name: 'newPasswordConfirm',
-      message: 'Enter your new password again:',
-      validate: (entry) => entry.length > 0,
-    });
-  }
-
-  inquirer.prompt(questions).then((answers) => {
-    if (answers.currentPassword) currentPassword = answers.currentPassword;
-    if (answers.newPassword) {
-      if (answers.newPassword === answers.newPasswordConfirm) {
-        newPassword = answers.newPassword;
-      } else {
-        LOGGER.info(chalk.red('New password values do not match'));
-        process.exit(1);
-      }
-    }
-
-    callUpdatePassword(currentPassword, newPassword);
-  });
-}
+});
 

--- a/src/bin/cryptid-user-change-password.js
+++ b/src/bin/cryptid-user-change-password.js
@@ -18,10 +18,7 @@ program
 let currentPassword = program.currentPassword;
 let newPassword = program.newPassword;
 
-if (SETTINGS.needsLogin) {
-  LOGGER.info(chalk.red('You must first login with "cryptid login"'));
-  process.exit(1);
-}
+SETTINGS.checkLogin();
 
 function callUpdatePassword(old, updated) {
   updatePassword(old, updated, (error, response) => {

--- a/src/bin/cryptid-version.js
+++ b/src/bin/cryptid-version.js
@@ -1,0 +1,3 @@
+import {LOGGER, loadVersion} from './cli';
+
+LOGGER.info(loadVersion());

--- a/src/bin/cryptid.js
+++ b/src/bin/cryptid.js
@@ -10,7 +10,7 @@ program
   .command('login', 'Login to Cryptid')
   .command('user', 'User actions')
   .command('accounts', 'Account actions')
-  // .command('products', 'Interact with products')
+  .command('products', 'Product actions')
   // .command('properties', 'Interact with properties')
   .command('server', 'Display the currently-configured server endpoint')
   .command('logout', 'Logout of Cryptid')

--- a/src/bin/cryptid.js
+++ b/src/bin/cryptid.js
@@ -1,17 +1,16 @@
-import path from 'path';
+import {loadHelp, loadVersion} from './cli';
+
 import program from 'commander';
 
-let version = require(path.join(__dirname, '../..', 'package.json'))
-  .version;
-
 program
-  .version(version)
-  .description('Admin interface to Cryptid Analytics')
+  .version(loadVersion())
+  .description(loadHelp('cryptid'))
   .command('login', 'Login to Cryptid')
+  .command('logout', 'Logout of Cryptid')
   .command('user', 'User actions')
   .command('accounts', 'Account actions')
   .command('products', 'Product actions')
   // .command('properties', 'Interact with properties')
   .command('server', 'Display the currently-configured server endpoint')
-  .command('logout', 'Logout of Cryptid')
+  .command('version', 'Print version')
   .parse(process.argv);

--- a/src/bin/help/cryptid.txt
+++ b/src/bin/help/cryptid.txt
@@ -1,0 +1,4 @@
+Command-line Cryptid Analytics client
+
+  Login with your cryptid service credentials using 'cryptid login' and then
+  most commands should be available.


### PR DESCRIPTION
This PR does some refactoring around how we interact with the internal `cli` module, as well as adds commands around the `products` piece of the API.

```bash
$ cryptid products list --account-id=1
$ cryptid products create --account-id=1 --product-name=Cardigan
$ cryptid products update --account-id=1 --product-id=30 --product-name=HelloWorld
```

Finally, the help for each command has now been extracted into txt files to make it easier to format more advanced help for each command.