### PR TITLE
Properties CLI support

### DIFF
--- a/src/bin/cli.js
+++ b/src/bin/cli.js
@@ -222,3 +222,54 @@ export function updateProduct(data, callback) {
     callback(response, body);
   });
 }
+
+export function createProperty(data, callback) {
+  let {
+    accountId,
+    productId,
+    propertyName,
+    propertyType,
+  } = data;
+
+  let options = {
+    url: buildUrl(`/api/accounts/${accountId}/products/${productId}/properties`),
+    method: 'post',
+    headers: {Authorization: `Token token=${TOKEN}`},
+    json: {
+      property: {
+        name: propertyName,
+        propertyType: propertyType
+      }
+    }
+  };
+
+  request(options, (error, response, body) => {
+    checkError(error);
+    callback(response, body);
+  });
+}
+
+export function updateProperty(data, callback) {
+  let {
+    accountId,
+    productId,
+    propertyName,
+    propertyId,
+  } = data;
+
+  let options = {
+    url: buildUrl(`/api/accounts/${accountId}/products/${productId}/properties/${propertyId}`),
+    method: 'put',
+    headers: {Authorization: `Token token=${TOKEN}`},
+    json: {
+      property: {
+        name: propertyName,
+      }
+    }
+  };
+
+  request(options, (error, response, body) => {
+    checkError(error);
+    callback(response, body);
+  });
+}

--- a/src/bin/cli.js
+++ b/src/bin/cli.js
@@ -33,8 +33,18 @@ export const SETTINGS = loadSettings();
 export const TOKEN = SETTINGS.token;
 
 function checkError(error) {
-  if (error && error.code === 'ENOTFOUND') {
-    LOGGER.info(chalk.red(`Could not reach cryptid server. Is ${SERVER} reachable?`));
+  if (error) {
+    switch (error.code) {
+      case 'ENOTFOUND':
+        LOGGER.info(chalk.red(`Could not reach cryptid server. Is ${SERVER} reachable?`));
+        break;
+      case 'ECONNREFUSED':
+        LOGGER.info(chalk.red(`Could not reach cryptid server. Is ${SERVER} reachable?`));
+        break;
+      default:
+        LOGGER.error(chalk.red(`An error occurred communicating with ${SERVER}`));
+        break;
+    }
     process.exit(1);
   }
 }

--- a/src/bin/cryptid-properties-create.js
+++ b/src/bin/cryptid-properties-create.js
@@ -1,0 +1,60 @@
+import {
+  LOGGER,
+  SETTINGS,
+  createProperty
+} from './cli';
+
+import Table from 'easy-table';
+import chalk from 'chalk';
+import {head} from 'lodash';
+import program from 'commander';
+
+program
+  .description('Create new property for a given account and product')
+  .option('-a, --account-id <accountId>', 'Account to create the property under')
+  .option('-p, --product-id <productId>', 'Product to create the property under')
+  .option('-n, --property-name <name>', 'Property name')
+  .option('-t, --property-type <type>', 'Type of property (web or mobile)')
+  .parse(process.argv);
+
+SETTINGS.checkLogin();
+
+if (!program.accountId) {
+  LOGGER.error(chalk.red('Account ID is required (use -a <accountId>)'));
+  process.exit(1);
+}
+
+if (!program.productId) {
+  LOGGER.error(chalk.red('Product ID is required (use -p <productId>)'));
+  process.exit(1);
+}
+
+if (!program.propertyName) {
+  LOGGER.error(chalk.red('Property name is required (use -n <propertyName>)'));
+  process.exit(1);
+}
+
+if (!program.propertyType) {
+  LOGGER.error(chalk.red('Property type is required (use -t web or -t mobile)'));
+  process.exit(1);
+}
+
+createProperty(program, (response, body) => {
+  if (response.statusCode === 201) {
+    LOGGER.info(chalk.green('Property was created successfully'));
+    let t = new Table();
+
+    let property = body.data;
+
+    t.cell('ID', property.id);
+    t.cell('Property Name', property.name);
+    t.cell('Type', head(property.trackerId.split('|')));
+    t.cell('Tracker ID', property.trackerId);
+    t.newRow();
+
+    LOGGER.info(t.toString());
+  } else {
+    LOGGER.error(chalk.red('Error creating property'));
+    process.exit(1);
+  }
+});

--- a/src/bin/cryptid-properties-list.js
+++ b/src/bin/cryptid-properties-list.js
@@ -1,0 +1,67 @@
+import {
+  LOGGER,
+  SETTINGS,
+  fetchCurrentUser
+} from './cli';
+import {filter, head} from 'lodash';
+
+import Table from 'easy-table';
+import chalk from 'chalk';
+import program from 'commander';
+
+program
+  .description('List accessible properties')
+  .option('-a, --account-id <accountId>', 'List properties only belonging to this account')
+  .option('-p, --product-id <productId>', 'List properties only belonging to this product')
+  .parse(process.argv);
+
+SETTINGS.checkLogin();
+
+fetchCurrentUser((response, body) => {
+  let properties = [];
+
+  body.data.accounts.forEach((account) => {
+    account.products.forEach((product) => {
+      product.properties.forEach((property) => {
+        properties.push({
+          ...property,
+          accountId: account.id,
+          accountName: account.name,
+          productId: product.id,
+          productName: product.name,
+        });
+      });
+    });
+  });
+
+  if (program.accountId) {
+    let accountId = parseInt(program.accountId, 10);
+    properties = filter(properties, {accountId});
+  }
+
+  if (program.productId) {
+    let productId = parseInt(program.productId, 10);
+    properties = filter(properties, {productId});
+  }
+
+  if (properties.length === 0) {
+    LOGGER.info(chalk.yellow('No matching properties found'));
+    process.exit();
+  }
+
+  let t = new Table();
+
+  properties.forEach((property) => {
+    t.cell('ID', property.id);
+    t.cell('Property Name', property.name);
+    t.cell('Type', head(property.trackerId.split('|')));
+    t.cell('Tracker', property.trackerId);
+    t.cell('Product (ID)', `${property.productName} (${property.productId})`);
+    t.cell('Account (ID)', `${property.accountName} (${property.accountId})`);
+    t.newRow();
+  });
+
+  t.sort(['Account (ID)', 'Product (ID)', 'Property Name']);
+
+  LOGGER.info(t.toString());
+});

--- a/src/bin/cryptid-properties-update.js
+++ b/src/bin/cryptid-properties-update.js
@@ -1,0 +1,60 @@
+import {
+  LOGGER,
+  SETTINGS,
+  updateProperty
+} from './cli';
+
+import Table from 'easy-table';
+import chalk from 'chalk';
+import {head} from 'lodash';
+import program from 'commander';
+
+program
+  .description('Updates a property')
+  .option('-a, --account-id <accountId>', 'Account to create the property under')
+  .option('-p, --product-id <productId>', 'Product to create the property under')
+  .option('-r, --property-id <propertyId>', 'Property to change')
+  .option('-n, --property-name <name>', 'Property name')
+  .parse(process.argv);
+
+SETTINGS.checkLogin();
+
+if (!program.accountId) {
+  LOGGER.error(chalk.red('Account ID is required (use -a <accountId>)'));
+  process.exit(1);
+}
+
+if (!program.productId) {
+  LOGGER.error(chalk.red('Product ID is required (use -p <productId>)'));
+  process.exit(1);
+}
+
+if (!program.propertyId) {
+  LOGGER.error(chalk.red('Property ID is required (use -r <propertyId>)'));
+  process.exit(1);
+}
+
+if (!program.propertyName) {
+  LOGGER.error(chalk.red('Property name is required (use -n <propertyName>)'));
+  process.exit(1);
+}
+
+updateProperty(program, (response, body) => {
+  if (response.statusCode === 200) {
+    LOGGER.info(chalk.green('Property was updated successfully'));
+    let t = new Table();
+
+    let property = body.data;
+
+    t.cell('ID', property.id);
+    t.cell('Property Name', property.name);
+    t.cell('Type', head(property.trackerId.split('|')));
+    t.cell('Tracker ID', property.trackerId);
+    t.newRow();
+
+    LOGGER.info(t.toString());
+  } else {
+    LOGGER.error(chalk.red('Error updating property'));
+    process.exit(1);
+  }
+});

--- a/src/bin/cryptid-properties.js
+++ b/src/bin/cryptid-properties.js
@@ -1,0 +1,9 @@
+import {loadHelp} from './cli';
+import program from 'commander';
+
+program
+  .description(loadHelp('cryptid-properties'))
+  .command('list', 'List accessible properties')
+  .command('create', 'Create property')
+  .command('update', 'Update a property')
+  .parse(process.argv);

--- a/src/bin/cryptid.js
+++ b/src/bin/cryptid.js
@@ -10,7 +10,7 @@ program
   .command('user', 'User actions')
   .command('accounts', 'Account actions')
   .command('products', 'Product actions')
-  // .command('properties', 'Interact with properties')
+  .command('properties', 'Property actions')
   .command('server', 'Display the currently-configured server endpoint')
   .command('version', 'Print version')
   .parse(process.argv);

--- a/src/bin/help/cryptid-properties.txt
+++ b/src/bin/help/cryptid-properties.txt
@@ -1,0 +1,12 @@
+Interact with Cryptid Analytics Properties
+
+  When using Cryptid Analytics, "properties" are the most fine-grain
+  organizing structures in the hierarchy. Whereas an "account" may map to a
+  company or other large-scaleo development organization and a "product" maps
+  to a single offering by said organization, a "property" maps most closely
+  to a code base.
+
+  Example: I want to track analytics for my Cheese Grater app, but I have a
+  front-end application as well as well as an API service and a mobile
+  application. In my case I'd have a single product, with three properties
+  for the web, api and mobile code bases.


### PR DESCRIPTION
Implements the following commands in the CLI:

```bash
$ cryptid properties list
$ cryptid properties create --account-id=3 --product-id=20 --property-name="Cardigan Web" --property-type=web
$ cryptid properties update --account-id=3 --product-id=20 --property-id=55 --property-name="Weeble Web"
```

Also improves out ability to detect different transport-level HTTP errors so we can give better feedback to the user.