### PR TITLE
Querying Support

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,19 +2,127 @@
 
 Javascript client for Cryptid Analytics
 
-## Usage
+This library should be used to integrate [Cryptid
+Analytics](https://cryptid.adorable.io) into web-based javascript applications
+(React, Vue, etc. or a simple script tag at the bottome of a static page.)
 
-Install
+For [React Native]() javascript projects, use
+[cryptid-react-native](https://github.com/adorableio/cryptid-react-native),
+which will gather device information rather than browser information.
+
+## Install
+
+To install into a project:
 
 ```bash
 npm install cryptid --save
 ```
 
-Configure
+To install for CLI usage only:
 
-Use
+```bash
+npm install cryptid --global
+```
 
-### CLI Client
+## Configure
+
+Create a new `Tracker` using the `trackerId` of the property you're tracking.
+
+```javascript
+import Tracker from 'cryptid';
+
+const tracker = new Tracker('web|AB5A928D-7244-4A07-9653-E4557C500C53')
+```
+
+You may also supply additional options as a second argument. They will be
+passed through to the [reqwest](https://github.com/ded/reqwest) ajax call.
+
+```javascript
+import Tracker from 'cryptid';
+
+const tracker = new Tracker('web|AB5A928D-7244-4A07-9653-E4557C500C53', {
+  success: (response) => console.log(response),
+  error: (err) => console.error(err),
+});
+```
+
+### React/Redux
+
+In a react+redux application, you may want to consider intializing a `Tracker`
+instance in your store, and then tracking events when actions are fired or when
+reducers commit changes to the store.
+
+
+## Use
+
+**`Tracker` has one method: `send`**, which is used to send an event to the
+cryptid service. When you call `send` the library gathers browser metadata to
+include with the event data you supply. All of this metadata may be overridden
+by fields you include on the event object (see the [Events](#events) section
+below.)
+
+Simple example:
+
+```javascript
+tracker.send({eventValue: 'button-clicked'});
+```
+
+More complex:
+
+```javascript
+tracker.send({
+  eventCategory: 'eCommerce',
+  eventAction: 'checkout',
+  eventValue: 'checkout-initiated',
+  customField1: 'abc123456789', // user id
+  customField2: 5, // items in cart
+  customField3: 'email', // referral code
+});
+```
+
+### Events
+
+List of fields that can be included in the event object:
+
+| Field | Description | Required? | Example |
+|-------|-------------|-----------|---------|
+| `eventCategory` | Category of the event | No | `Authentication` |
+| `eventAction` | Action or workflow the event occured during | No | `Login` |
+| `eventLabel` | Label of the event | No | `form-submission` |
+| `eventValue` | Value of the event | Yes | `button-click` or `enter-key` |
+| `customField_1` | Custom data | No | |
+| `customField_2` | Custom data | No | |
+| `customField_3` | Custom data | No | |
+| `customField_4` | Custom data | No | |
+| `customField_5` | Custom data | No | |
+
+**You may use the Category, Action, Label and Value event fields any way that
+you'd like in your application**; they exist merely to allow for an event
+taxonomy that works for you. The simplest way to use them is to only supply an
+event value such as `login-successful`. If you don't need anything more
+complicated, you may omit the rest of the fields.
+
+Likewise, the `customField` values are there to log supplemental application
+information that may bes useful to you, but are not required by the `send`
+event or the service.
+
+List of browser metadata fields that are automatically collected and may be
+overridden by including them in the event object:
+
+| Field | Description | Exammple |
+|-------|-------------|
+| `documentLocationUrl` | URL of the page | `http://example.org/foo.html` |
+| `documentReferer` | Referrer (if any) of the page | `http://google.com` |
+| `documentEncoding` | The character set used on the page  | `UTF-8` |
+| `documentTitle` | The title of the page | `My Cool Application | Login` |
+| `documentHostname` | The hostname the page was served from | `example.org` |
+| `documentPath` | The document path of the page | `/foo.html` |
+| `userLanguage` | The configured language of the browser | `en-US` |
+| `screenResolution` | The resolution of the display | `2560x1417` |
+| `viewportSize` | The viewable size of the browser at the time of the event | `2560x1440` |
+| `screenColors` | The screen color depth | `24` |
+
+## CLI Client
 
 Installing the `cryptid` module also gives you access to a command-line admin
 client to the cryptid analytics service.
@@ -30,3 +138,4 @@ And then all functionality should be available. View available commands with:
 ```bash
 $(npm bin)/cryptid -h
 ```
+

--- a/README.md
+++ b/README.md
@@ -6,7 +6,8 @@ This library should be used to integrate [Cryptid
 Analytics](https://cryptid.adorable.io) into web-based javascript applications
 (React, Vue, etc. or a simple script tag at the bottome of a static page.)
 
-For [React Native]() javascript projects, use
+For [React Native](https://facebook.github.io/react-native/) javascript
+projects, use
 [cryptid-react-native](https://github.com/adorableio/cryptid-react-native),
 which will gather device information rather than browser information.
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -4,6 +4,12 @@
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
+    "@types/graphql": {
+      "version": "0.10.2",
+      "resolved": "https://registry.npmjs.org/@types/graphql/-/graphql-0.10.2.tgz",
+      "integrity": "sha512-Ayw0w+kr8vYd8DToiMXjcHxXv1ljWbqX2mnLwXDxkBgog3vywGriC0JZ+npsuohKs3+E88M8OOtobo4g0X3SIA==",
+      "optional": true
+    },
     "abab": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/abab/-/abab-1.0.3.tgz",
@@ -128,6 +134,31 @@
       "requires": {
         "micromatch": "2.3.11",
         "normalize-path": "2.1.1"
+      }
+    },
+    "apollo-client": {
+      "version": "1.9.3",
+      "resolved": "https://registry.npmjs.org/apollo-client/-/apollo-client-1.9.3.tgz",
+      "integrity": "sha512-JABKKbqvcw8DJm3YUkEmyx1SK74i+/DesEtAtyocJi10LLmeMQYQFpg8W3BG1tZsYEQ3owEmPbsdNGTly+VOQg==",
+      "requires": {
+        "@types/graphql": "0.10.2",
+        "apollo-link-core": "0.5.4",
+        "graphql": "0.10.5",
+        "graphql-anywhere": "3.1.0",
+        "graphql-tag": "2.4.2",
+        "redux": "3.7.2",
+        "symbol-observable": "1.0.4",
+        "whatwg-fetch": "2.0.3"
+      }
+    },
+    "apollo-link-core": {
+      "version": "0.5.4",
+      "resolved": "https://registry.npmjs.org/apollo-link-core/-/apollo-link-core-0.5.4.tgz",
+      "integrity": "sha512-OxL0Kjizb0eS2ObldDqJEs/tFN9xI9RZuTJcaszgGy+xudoPXhIMCHMr7hGZhy0mK+U+BbBULZJw4YQU4J0ODQ==",
+      "requires": {
+        "graphql": "0.10.5",
+        "graphql-tag": "2.4.2",
+        "zen-observable-ts": "0.4.4"
       }
     },
     "append-transform": {
@@ -1968,6 +1999,14 @@
         "cssom": "0.3.2"
       }
     },
+    "csv-stringify": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/csv-stringify/-/csv-stringify-1.0.4.tgz",
+      "integrity": "sha1-vBi6ua1M7zGV/SV5gLWLR5xC0+U=",
+      "requires": {
+        "lodash.get": "4.4.2"
+      }
+    },
     "d": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/d/-/d-1.0.0.tgz",
@@ -2144,6 +2183,14 @@
       "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.20.tgz",
       "integrity": "sha1-Lu3VzLrn3cVX9orR/OnBcukV5OU=",
       "dev": true
+    },
+    "encoding": {
+      "version": "0.1.12",
+      "resolved": "https://registry.npmjs.org/encoding/-/encoding-0.1.12.tgz",
+      "integrity": "sha1-U4tm8+5izRq1HsMjgp0flIDHS+s=",
+      "requires": {
+        "iconv-lite": "0.4.13"
+      }
     },
     "end-of-stream": {
       "version": "1.4.0",
@@ -4100,6 +4147,24 @@
       "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.11.tgz",
       "integrity": "sha1-Dovf5NHduIVNZOBOp8AOKgJuVlg="
     },
+    "graphql": {
+      "version": "0.10.5",
+      "resolved": "https://registry.npmjs.org/graphql/-/graphql-0.10.5.tgz",
+      "integrity": "sha512-Q7cx22DiLhwHsEfUnUip1Ww/Vfx7FS0w6+iHItNuN61+XpegHSa3k5U0+6M5BcpavQImBwFiy0z3uYwY7cXMLQ==",
+      "requires": {
+        "iterall": "1.1.1"
+      }
+    },
+    "graphql-anywhere": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/graphql-anywhere/-/graphql-anywhere-3.1.0.tgz",
+      "integrity": "sha1-PqDY6GRrXO5oA1AWqadVfBXCHpY="
+    },
+    "graphql-tag": {
+      "version": "2.4.2",
+      "resolved": "https://registry.npmjs.org/graphql-tag/-/graphql-tag-2.4.2.tgz",
+      "integrity": "sha1-amMpfYUi0DorctJvGyOaqzQ4QM0="
+    },
     "growly": {
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/growly/-/growly-1.3.0.tgz",
@@ -4237,8 +4302,7 @@
     "iconv-lite": {
       "version": "0.4.13",
       "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.13.tgz",
-      "integrity": "sha1-H4irpKsLFQjoMSrMOTRfNumS4vI=",
-      "dev": true
+      "integrity": "sha1-H4irpKsLFQjoMSrMOTRfNumS4vI="
     },
     "ignore": {
       "version": "3.3.5",
@@ -4568,8 +4632,7 @@
     "is-stream": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-1.1.0.tgz",
-      "integrity": "sha1-EtSj3U5o4Lec6428hBc66A2RykQ=",
-      "dev": true
+      "integrity": "sha1-EtSj3U5o4Lec6428hBc66A2RykQ="
     },
     "is-symbol": {
       "version": "1.0.1",
@@ -4607,6 +4670,15 @@
       "dev": true,
       "requires": {
         "isarray": "1.0.0"
+      }
+    },
+    "isomorphic-fetch": {
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/isomorphic-fetch/-/isomorphic-fetch-2.2.1.tgz",
+      "integrity": "sha1-YRrhrPFPXoH3KVB0coGf6XM1WKk=",
+      "requires": {
+        "node-fetch": "1.7.3",
+        "whatwg-fetch": "2.0.3"
       }
     },
     "isstream": {
@@ -4713,6 +4785,11 @@
       "requires": {
         "handlebars": "4.0.10"
       }
+    },
+    "iterall": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/iterall/-/iterall-1.1.1.tgz",
+      "integrity": "sha1-9/CvEemgTsZCYmD1AZ2fzKTVAhQ="
     },
     "jest": {
       "version": "21.0.1",
@@ -5383,8 +5460,7 @@
     "js-tokens": {
       "version": "3.0.2",
       "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-3.0.2.tgz",
-      "integrity": "sha1-mGbfOVECEw449/mWvOtlRDIJwls=",
-      "dev": true
+      "integrity": "sha1-mGbfOVECEw449/mWvOtlRDIJwls="
     },
     "js-yaml": {
       "version": "3.9.1",
@@ -5595,6 +5671,16 @@
       "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.4.tgz",
       "integrity": "sha1-eCA6TRwyiuHYbcpkYONptX9AVa4="
     },
+    "lodash-es": {
+      "version": "4.17.4",
+      "resolved": "https://registry.npmjs.org/lodash-es/-/lodash-es-4.17.4.tgz",
+      "integrity": "sha1-3MHXVS4VCgZABzupyzHXDwMpUOc="
+    },
+    "lodash.get": {
+      "version": "4.4.2",
+      "resolved": "https://registry.npmjs.org/lodash.get/-/lodash.get-4.4.2.tgz",
+      "integrity": "sha1-LRd/ZS+jHpObRDjVNBSZ36OCXpk="
+    },
     "longest": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/longest/-/longest-1.0.1.tgz",
@@ -5605,7 +5691,6 @@
       "version": "1.3.1",
       "resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.3.1.tgz",
       "integrity": "sha1-0aitM/qc4OcT1l/dCsi3SNR4yEg=",
-      "dev": true,
       "requires": {
         "js-tokens": "3.0.2"
       }
@@ -5755,6 +5840,15 @@
       "dev": true,
       "requires": {
         "inherits": "2.0.3"
+      }
+    },
+    "node-fetch": {
+      "version": "1.7.3",
+      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-1.7.3.tgz",
+      "integrity": "sha512-NhZ4CsKx7cYm2vSrBAr2PvFOe6sWDf0UYLRqA6svUYg7+/TSfVAu49jYC4BvQ4Sms9SZgdqGBgroqfDhJdTyKQ==",
+      "requires": {
+        "encoding": "0.1.12",
+        "is-stream": "1.1.0"
       }
     },
     "node-int64": {
@@ -6448,6 +6542,17 @@
         "resolve": "1.1.7"
       }
     },
+    "redux": {
+      "version": "3.7.2",
+      "resolved": "https://registry.npmjs.org/redux/-/redux-3.7.2.tgz",
+      "integrity": "sha512-pNqnf9q1hI5HHZRBkj3bAngGZW/JMCmexDlOxw4XagXY2o1327nHH54LoTjiPJ0gizoqPDRqWyX/00g0hD6w+A==",
+      "requires": {
+        "lodash": "4.17.4",
+        "lodash-es": "4.17.4",
+        "loose-envify": "1.3.1",
+        "symbol-observable": "1.0.4"
+      }
+    },
     "regenerate": {
       "version": "1.3.2",
       "resolved": "https://registry.npmjs.org/regenerate/-/regenerate-1.3.2.tgz",
@@ -6960,6 +7065,11 @@
         "has-flag": "2.0.0"
       }
     },
+    "symbol-observable": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/symbol-observable/-/symbol-observable-1.0.4.tgz",
+      "integrity": "sha1-Kb9hXUqnEhvdiYsi1LP5vE4qoD0="
+    },
     "symbol-tree": {
       "version": "3.2.2",
       "resolved": "https://registry.npmjs.org/symbol-tree/-/symbol-tree-3.2.2.tgz",
@@ -7370,6 +7480,11 @@
         "iconv-lite": "0.4.13"
       }
     },
+    "whatwg-fetch": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/whatwg-fetch/-/whatwg-fetch-2.0.3.tgz",
+      "integrity": "sha1-nITsLc9oGH/wC8ZOEnS0QhduHIQ="
+    },
     "whatwg-url": {
       "version": "4.8.0",
       "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-4.8.0.tgz",
@@ -7571,6 +7686,11 @@
           "dev": true
         }
       }
+    },
+    "zen-observable-ts": {
+      "version": "0.4.4",
+      "resolved": "https://registry.npmjs.org/zen-observable-ts/-/zen-observable-ts-0.4.4.tgz",
+      "integrity": "sha512-SNVY1sWWhoe7FwFmHpD9ERi+7Mhhj3+JdS0BGy2UxLIg7cY+3zQbyZauQCI6DN6YK4uoKNaIm3S7Qkqi1Lr+Fw=="
     }
   }
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cryptid",
-  "version": "0.2.0",
+  "version": "0.3.0",
   "description": "javascript client to cryptid analytics",
   "website": "https://cryptid.adorable.io",
   "main": "dist/index.js",

--- a/package.json
+++ b/package.json
@@ -48,11 +48,15 @@
     ]
   },
   "dependencies": {
+    "apollo-client": "^1.9.3",
     "chalk": "^2.1.0",
     "cli-logger": "^0.5.40",
     "commander": "^2.11.0",
+    "csv-stringify": "^1.0.4",
     "easy-table": "^1.1.0",
+    "graphql-tag": "^2.4.2",
     "inquirer": "^3.2.3",
+    "isomorphic-fetch": "^2.2.1",
     "lodash": "^4.17.4",
     "md5": "^2.2.1",
     "preferences": "^0.2.1",

--- a/src/bin/cli.js
+++ b/src/bin/cli.js
@@ -1,6 +1,10 @@
+import ApolloClient, { createNetworkInterface } from 'apollo-client';
+
 import Preferences from 'preferences';
 import chalk from 'chalk';
 import createLogger from 'cli-logger';
+// eslint-disable-next-line no-unused-vars
+import fetch from 'isomorphic-fetch';
 import fs from 'fs';
 import md5 from 'md5';
 import path from 'path';
@@ -8,7 +12,7 @@ import request from 'request';
 import url from 'url';
 
 export const SERVER = process.env.CRYPTID_SERVER || 'https://cryptid.adorable.io';
-export const LOGGER = createLogger({level: createLogger.INFO});
+export const LOGGER = createLogger({ level: createLogger.INFO });
 
 function buildUrl(uri) {
   return url.resolve(SERVER, uri);
@@ -16,7 +20,7 @@ function buildUrl(uri) {
 
 function loadSettings() {
   let name = `com.adorable.cryptid.${md5(SERVER)}`;
-  let settings = new Preferences(name, {server: SERVER, token: '', email: ''});
+  let settings = new Preferences(name, { server: SERVER, token: '', email: '' });
 
   let loggedIn = settings.token.length > 0 && settings.email.length > 0;
   settings.loggedIn = loggedIn;
@@ -66,6 +70,23 @@ export function loadVersion() {
 
 /* =========================================================
  *
+ *  GraphQL Functions
+ *
+ *  ========================================================= */
+
+export function buildGQLClient() {
+  return new ApolloClient({
+    networkInterface: createNetworkInterface({
+      uri: url.resolve(SERVER, '/api/reports'),
+      opts: {
+        headers: { Authorization: `Token token=${TOKEN}` }
+      }
+    })
+  });
+}
+
+/* =========================================================
+ *
  *  Cryptid Service Functions
  *
  * ========================================================= */
@@ -100,7 +121,7 @@ export function fetchCurrentUser(callback) {
     url: buildUrl('/api/users/current'),
     method: 'get',
     json: true,
-    headers: {Authorization: `Token token=${TOKEN}`}
+    headers: { Authorization: `Token token=${TOKEN}` }
   };
 
   request(options, (error, response, body) => {
@@ -113,7 +134,7 @@ export function createAccount(accountName, callback) {
   let options = {
     url: buildUrl('/api/accounts'),
     method: 'post',
-    headers: {Authorization: `Token token=${TOKEN}`},
+    headers: { Authorization: `Token token=${TOKEN}` },
     json: {
       account: {
         name: accountName
@@ -131,7 +152,7 @@ export function updateAccount(accountId, accountName, callback) {
   let options = {
     url: buildUrl(`/api/accounts/${accountId}`),
     method: 'put',
-    headers: {Authorization: `Token token=${TOKEN}`},
+    headers: { Authorization: `Token token=${TOKEN}` },
     json: {
       account: {
         name: accountName
@@ -149,7 +170,7 @@ export function addUserToAccount(accountId, email, callback) {
   let options = {
     url: buildUrl(`/api/accounts/${accountId}/users`),
     method: 'post',
-    headers: {Authorization: `Token token=${TOKEN}`},
+    headers: { Authorization: `Token token=${TOKEN}` },
     json: {
       user: {
         email: email
@@ -164,12 +185,12 @@ export function addUserToAccount(accountId, email, callback) {
 }
 
 export function updatePassword(passwords, callback) {
-  let {currentPassword, newPassword, newPasswordConfirm} = passwords;
+  let { currentPassword, newPassword, newPasswordConfirm } = passwords;
 
   let options = {
     url: buildUrl('/api/users/current'),
     method: 'put',
-    headers: {Authorization: `Token token=${TOKEN}`},
+    headers: { Authorization: `Token token=${TOKEN}` },
     json: {
       user: {
         current: currentPassword,
@@ -189,7 +210,7 @@ export function createProduct(accountId, productName, callback) {
   let options = {
     url: buildUrl(`/api/accounts/${accountId}/products`),
     method: 'post',
-    headers: {Authorization: `Token token=${TOKEN}`},
+    headers: { Authorization: `Token token=${TOKEN}` },
     json: {
       product: {
         name: productName
@@ -204,12 +225,12 @@ export function createProduct(accountId, productName, callback) {
 }
 
 export function updateProduct(data, callback) {
-  let {accountId, productId, productName} = data;
+  let { accountId, productId, productName } = data;
 
   let options = {
     url: buildUrl(`/api/accounts/${accountId}/products/${productId}`),
     method: 'put',
-    headers: {Authorization: `Token token=${TOKEN}`},
+    headers: { Authorization: `Token token=${TOKEN}` },
     json: {
       product: {
         name: productName
@@ -234,7 +255,7 @@ export function createProperty(data, callback) {
   let options = {
     url: buildUrl(`/api/accounts/${accountId}/products/${productId}/properties`),
     method: 'post',
-    headers: {Authorization: `Token token=${TOKEN}`},
+    headers: { Authorization: `Token token=${TOKEN}` },
     json: {
       property: {
         name: propertyName,
@@ -260,7 +281,7 @@ export function updateProperty(data, callback) {
   let options = {
     url: buildUrl(`/api/accounts/${accountId}/products/${productId}/properties/${propertyId}`),
     method: 'put',
-    headers: {Authorization: `Token token=${TOKEN}`},
+    headers: { Authorization: `Token token=${TOKEN}` },
     json: {
       property: {
         name: propertyName,

--- a/src/bin/cryptid-query.js
+++ b/src/bin/cryptid-query.js
@@ -1,0 +1,52 @@
+import {LOGGER, SETTINGS, buildGQLClient} from './cli';
+
+import chalk from 'chalk';
+import csvify from 'csv-stringify';
+import fs from 'fs';
+import gql from 'graphql-tag';
+import program from 'commander';
+
+program
+  .option('-g, --graph-ql <queryDocument>', 'Custom query document')
+  .option('-t, --tracker-id <trackerId>', 'Tracker to fetch events for')
+  .option('-f, --format <format>', 'Output format', /^(csv|json)$/i, 'csv')
+  .parse(process.argv);
+
+SETTINGS.checkLogin();
+
+const client = buildGQLClient();
+let queryDocument = '';
+
+if (program.graphQl) {
+  queryDocument = fs.readFileSync(program.graphQl, 'utf8');
+} else {
+  queryDocument = `{ events(tracker_id: "${program.trackerId}") { event_value } }`;
+}
+
+const queryOpts = {
+  query: gql(queryDocument)
+};
+
+client.query(queryOpts)
+  .catch(err => LOGGER.error(chalk.red(err)) && process.exit(1))
+  .then(resp => {
+    const events = resp.data.events.map(event => {
+      // eslint-disable-next-line no-unused-vars
+      let {__typename, ...mappedEvent} = event;
+      return mappedEvent;
+    });
+
+    switch (program.format) {
+      case 'json':
+        LOGGER.info(JSON.stringify(events));
+        break;
+      case 'csv':
+      default:
+        const opts = {header: true};
+        csvify(events, opts, (err, output) => {
+          LOGGER.info(output);
+        });
+        break;
+    }
+
+  });

--- a/src/bin/cryptid.js
+++ b/src/bin/cryptid.js
@@ -11,6 +11,7 @@ program
   .command('accounts', 'Account actions')
   .command('products', 'Product actions')
   .command('properties', 'Property actions')
+  .command('query', 'Query the event store for a property')
   .command('server', 'Display the currently-configured server endpoint')
   .command('version', 'Print version')
   .parse(process.argv);


### PR DESCRIPTION
Also updates the README with actual usage information.

Right now we mainly support querying via an external query document that it passes through to the graphql interface. In time we can expand the support for command-line filtering and ordering, but that stuff isn't in the server implementation yet so there's no need to support it here.